### PR TITLE
Add release packaging workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ jobs:
             - uses: actions/checkout@v2
 
             - name: Use Node.js
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
-                  node-version: "16.x"
+                  node-version: "20"
 
             - name: Install dependencies
               run: npm install
@@ -26,12 +26,16 @@ jobs:
             - name: Bundle
               run: npm run build
 
+            - name: Package
+              run: zip -j obsidian-task-archiver.zip main.js manifest.json styles.css
+
             - name: Release
               uses: softprops/action-gh-release@v1
               with:
                   name: ${{  github.ref_name }}
                   tag_name: ${{ github.ref }}
                   files: |
+                      obsidian-task-archiver.zip
                       main.js
                       manifest.json
                       styles.css

--- a/.github/workflows/spec.md
+++ b/.github/workflows/spec.md
@@ -1,0 +1,12 @@
+# GitHub Workflows
+
+## release.yml
+Builds and releases the plugin when a tag is pushed. It installs dependencies, runs tests, bundles the plugin with Rollup, zips the distribution, and attaches assets to a GitHub release.
+
+```mermaid
+flowchart TD
+  A[Tag Push] --> B[Install & Test]
+  B --> C[Bundle]
+  C --> D[Zip Assets]
+  D --> E[Create GitHub Release]
+```


### PR DESCRIPTION
## Summary
- build Obsidian plugin on tag push
- zip artifacts before attaching to GitHub Release
- document workflow in `.github/workflows/spec.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ad7fc12dc832cad31ef3f0c3cd74b