### PR TITLE
Fix build error with Object.fromEntries

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
         "skipLibCheck": true,
         "moduleResolution": "node",
         "importHelpers": true,
-        "lib": ["dom", "es5", "scripthost", "es2015"],
+        "lib": ["dom", "es5", "scripthost", "es2015", "es2019"],
         "allowSyntheticDefaultImports": true,
         "esModuleInterop": true,
         "jsx": "preserve",


### PR DESCRIPTION
## Summary
- extend TypeScript libs to include `es2019`

## Testing
- `npm run typescript`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ae24eedcc832caefba0a4a8ced5b8