### PR TITLE
Enable frontmatter placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ You can use several placeholders throughout the settings to build cool workflows
     -   Resolves to the path from the root of the vault to the file you're in
 -   `{{heading}}`
     -   Points to the heading above the task
--   `{{headingChain}}`)
+-   `{{headingChain}}`
     -   Creates a chain from headings above the task. E.g. `Project 1 > Team 2`
 -   `{{frontmatter.<key>}}`
     -   Inserts the value of `<key>` from the note's front matter
@@ -225,8 +225,9 @@ A regular expression for replacing the contents of the task during archiving; th
 This might be useful if you want to see what you accomplished in a day:
 ![](metadata-demo.png)
 
-You can also pull values from the note's front matter. Specify a comma separated
-list of keys in **Front matter keys** setting. Use `*` to include all keys.
+You can pull values from the note's front matter using placeholders.
+For example:
+`[completion:: {{obsidianTasksCompletedDate}}] [impact:: {{frontmatter.impact}}]`
 
 ### Additional patterns to detect completed tasks
 

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -16,7 +16,6 @@ export interface AdditionalMetadataSettings {
     addMetadata: boolean;
     dateFormat: string;
     metadata: string;
-    frontmatterKeys: string;
 }
 
 export enum ArchiveFileType {
@@ -105,7 +104,6 @@ export const DEFAULT_SETTINGS: Settings = {
         addMetadata: true,
         dateFormat: DEFAULT_DATE_FORMAT,
         metadata: `🔒 [[${placeholders.DATE}]] 🕸️ ${placeholders.HEADING_CHAIN}`,
-        frontmatterKeys: "*",
     },
     additionalTaskPattern: "",
     archiveAllCheckedTaskTypes: false,
@@ -141,7 +139,6 @@ export const DEFAULT_SETTINGS_FOR_TESTS: Settings = {
     additionalMetadataBeforeArchiving: {
         ...DEFAULT_SETTINGS.additionalMetadataBeforeArchiving,
         addMetadata: false,
-        frontmatterKeys: "*",
     },
     defaultArchiveFileName: "folder/sub-folder/mock-file-base-name",
     headings: [{ text: "Archived" }],

--- a/src/features/__tests__/ArchiveFeature.test.js
+++ b/src/features/__tests__/ArchiveFeature.test.js
@@ -447,7 +447,6 @@ describe("Adding metadata to tasks", () => {
             ...DEFAULT_SETTINGS_FOR_TESTS.additionalMetadataBeforeArchiving,
             addMetadata: true,
             metadata,
-            frontmatterKeys: "*",
         },
     };
 
@@ -577,31 +576,14 @@ describe("Adding metadata to tasks", () => {
     describe("Front matter metadata", () => {
         test("Appends front matter variables", async () => {
             await archiveTasksAndCheckActiveFile(
-                ["---", "project: ta", "---", "- [x] foo", "# Archived"],
+                ["---", "impact: high", "---", "- [x] foo", "# Archived"],
                 [
                     "---",
-                    "project: ta",
+                    "impact: high",
                     "---",
                     "# Archived",
                     "",
-                    `- [x] foo ${metadataWithResolvedPlaceholders} project:: ta`,
-                    "",
-                ],
-                { settings: settingsForTestingMetadata }
-            );
-        });
-
-        test("Respects configured keys", async () => {
-            await archiveTasksAndCheckActiveFile(
-                ["---", "project: ta", "context: work", "---", "- [x] foo", "# Archived"],
-                [
-                    "---",
-                    "project: ta",
-                    "context: work",
-                    "---",
-                    "# Archived",
-                    "",
-                    `- [x] foo ${metadataWithResolvedPlaceholders} project:: ta`,
+                    `- [x] foo [impact:: high]`,
                     "",
                 ],
                 {
@@ -609,23 +591,23 @@ describe("Adding metadata to tasks", () => {
                         ...settingsForTestingMetadata,
                         additionalMetadataBeforeArchiving: {
                             ...settingsForTestingMetadata.additionalMetadataBeforeArchiving,
-                            frontmatterKeys: "project",
+                            metadata: "[impact:: {{frontmatter.impact}}]",
                         },
                     },
                 }
             );
         });
 
-        test("No front matter appended when keys empty", async () => {
+        test("Missing key resolves to empty string", async () => {
             await archiveTasksAndCheckActiveFile(
-                ["---", "project: ta", "---", "- [x] foo", "# Archived"],
+                ["---", "impact: high", "---", "- [x] foo", "# Archived"],
                 [
                     "---",
-                    "project: ta",
+                    "impact: high",
                     "---",
                     "# Archived",
                     "",
-                    `- [x] foo ${metadataWithResolvedPlaceholders}`,
+                    `- [x] foo [impact:: ]`,
                     "",
                 ],
                 {
@@ -633,7 +615,7 @@ describe("Adding metadata to tasks", () => {
                         ...settingsForTestingMetadata,
                         additionalMetadataBeforeArchiving: {
                             ...settingsForTestingMetadata.additionalMetadataBeforeArchiving,
-                            frontmatterKeys: "",
+                            metadata: "[impact:: {{frontmatter.missing}}]",
                         },
                     },
                 }

--- a/src/services/MetadataService.ts
+++ b/src/services/MetadataService.ts
@@ -2,7 +2,6 @@ import { PlaceholderService } from "./PlaceholderService";
 
 import { Settings } from "../Settings";
 import { BlockWithRule } from "../types/Types";
-import { front_matter_to_meta, pick_front_matter } from "../util/FrontMatter";
 
 export class MetadataService {
   constructor(
@@ -26,16 +25,10 @@ export class MetadataService {
         dateFormat,
         block: task,
         heading: task.parentSection.text,
+        frontmatter: front_matter,
       });
 
-      const filtered = pick_front_matter(
-        front_matter,
-        this.settings.additionalMetadataBeforeArchiving.frontmatterKeys
-      );
-      const front_matter_metadata = front_matter_to_meta(filtered);
-      const suffix = [resolved_metadata, front_matter_metadata]
-        .filter((part) => part)
-        .join(" ");
+      const suffix = resolved_metadata;
 
       task.text = `${task.text} ${suffix}`.trim();
       return { task, rule };

--- a/src/services/PlaceholderService.ts
+++ b/src/services/PlaceholderService.ts
@@ -12,6 +12,7 @@ interface PlaceholderContext {
     dateFormat?: string;
     heading?: string;
     obsidianTasksCompletedDateFormat?: string;
+    frontmatter?: Record<string, unknown>;
 }
 
 export class PlaceholderService {
@@ -54,9 +55,10 @@ export class PlaceholderService {
             dateFormat = DEFAULT_DATE_FORMAT,
             heading = "", // todo: this too is inside a task, it should be removed
             obsidianTasksCompletedDateFormat = DEFAULT_DATE_FORMAT, // todo: this can be read from settings
+            frontmatter = {},
         }: PlaceholderContext = {}
     ) {
-        return text
+        const with_basic = text
             .replace(placeholders.ACTIVE_FILE, this.getActiveFileBaseName())
             .replace(placeholders.ACTIVE_FILE_NEW, this.getActiveFileBaseName())
             .replace(
@@ -79,5 +81,9 @@ export class PlaceholderService {
                     .moment(getTaskCompletionDate(block?.text))
                     .format(obsidianTasksCompletedDateFormat)
             );
+
+        return with_basic.replace(/{{frontmatter\.([\w-]+)}}/g, (_, key) =>
+            key in frontmatter ? String(frontmatter[key]) : ""
+        );
     }
 }

--- a/src/services/spec.md
+++ b/src/services/spec.md
@@ -1,15 +1,14 @@
 # Services
 
 ## MetadataService.appendMetadata(front_matter)
-Returns a function that appends configured metadata and provided front matter
-values to a task. Front matter can be filtered using `frontmatterKeys` setting.
+Returns a function that appends configured metadata to a task. Metadata may
+include placeholders resolved from the task context and note front matter.
 
 ```mermaid
 graph TD
   A[Task + Rule] --> B[appendMetadata(front_matter)]
   B --> C{Add?}
   C -->|yes| D[Resolve placeholders]
-  D --> E[Combine with front matter]
-  E --> F[Task with metadata]
+  D --> E[Task with metadata]
   C -->|no| F
 ```

--- a/src/settings-ui/components/ArchiverSettingsPage.tsx
+++ b/src/settings-ui/components/ArchiverSettingsPage.tsx
@@ -285,19 +285,6 @@ export function ArchiverSettingsPage(props: ArchiverSettingsPageProps) {
             value={settings.additionalMetadataBeforeArchiving.metadata}
             class="wide-input"
           />
-          <TextSetting
-            onInput={({ currentTarget: { value } }) => {
-              setSettings(
-                "additionalMetadataBeforeArchiving",
-                "frontmatterKeys",
-                value
-              );
-            }}
-            name="Front matter keys"
-            description="Comma separated keys from the note's front matter to add"
-            value={settings.additionalMetadataBeforeArchiving.frontmatterKeys}
-            class="wide-input"
-          />
           <PlaceholdersDescription
             placeholderResolver={props.placeholderService}
             extraPlaceholders={[

--- a/src/util/FrontMatter.ts
+++ b/src/util/FrontMatter.ts
@@ -33,24 +33,3 @@ export function front_matter_to_meta(front_matter: Record<string, unknown>): str
  * @param front_matter - Parsed front matter object.
  * @param keys - Comma separated list of keys to pick. Use '*' for all or leave empty for none.
  */
-export function pick_front_matter(
-  front_matter: Record<string, unknown>,
-  keys: string
-): Record<string, unknown> {
-  const trimmed = keys.trim();
-  if (trimmed === "*") {
-    return front_matter;
-  }
-  if (trimmed === "") {
-    return {};
-  }
-
-  const allowed = trimmed
-    .split(",")
-    .map((k) => k.trim())
-    .filter((k) => k);
-
-  return Object.fromEntries(
-    Object.entries(front_matter).filter(([key]) => allowed.includes(key))
-  );
-}

--- a/src/util/__tests__/FrontMatter.test.js
+++ b/src/util/__tests__/FrontMatter.test.js
@@ -1,7 +1,6 @@
 import {
   parse_front_matter,
   front_matter_to_meta,
-  pick_front_matter,
 } from "../FrontMatter";
 
 test("parses yaml front matter", () => {
@@ -15,18 +14,3 @@ test("converts front matter to metadata", () => {
   expect(meta).toBe("foo:: bar baz:: qux");
 });
 
-test("picks specific keys from front matter", () => {
-  const picked = pick_front_matter(
-    { foo: "bar", baz: "qux" },
-    "foo"
-  );
-  expect(picked).toEqual({ foo: "bar" });
-});
-
-test("returns all when keys empty", () => {
-  const picked = pick_front_matter(
-    { foo: "bar", baz: "qux" },
-    ""
-  );
-  expect(picked).toEqual({});
-});

--- a/src/util/spec.md
+++ b/src/util/spec.md
@@ -15,6 +15,3 @@ graph TD
   C --> D(front_matter_to_meta)
   D --> E[Metadata String]
 ```
-
-## pick_front_matter(front_matter, keys)
-Returns a front matter object with only the specified keys. Use `"*"` or an empty string to keep all keys.


### PR DESCRIPTION
## Summary
- remove frontmatter keys option
- support `{{frontmatter.*}}` placeholders
- update docs
- update tests

## Testing
- `npm test`
- `npm run lint` *(fails: 124 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684aeb77f9b4832c8675cb52e711f7db